### PR TITLE
docs: fix doc repository base URL

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -2,7 +2,7 @@
 export default {
   projectLink: 'https://github.com/raisiqueira/headless-stepper-monorepo',
   docsRepositoryBase:
-    'https://github.com/raisiqueira/headless-stepper-monorepo/tree/main/packages/docs/pages',
+    'https://github.com/raisiqueira/headless-stepper-monorepo/tree/main/docs/pages',
   titleSuffix: ' – Headless Stepper',
   nextLinks: true,
   prevLinks: true,


### PR DESCRIPTION
Fix value of the attribute `docsRepositoryBase` used in the documentation's site to redirect the user to Github's edit page